### PR TITLE
Update Catch2 to v2.13.7.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(NOT Catch2_FOUND)
   include(FetchContent)
   FetchContent_Declare(catch2
                        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                       GIT_TAG v2.9.1)
+                       GIT_TAG v2.13.7)
 
   FetchContent_GetProperties(catch2)
   if(NOT catch2_POPULATED)


### PR DESCRIPTION
Update the test framework to the latest release. This picks up the
change in v2.13.5 to work with dynamic stack sizes in glibc v2.34.

Closes #38