### PR TITLE
cmake: upgrade catch2 to the latest version (v2.13.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,12 +89,12 @@ endif()
 # Dependencies ###################
 
 if(BUILD_TESTING)
-find_package(Catch2 QUIET)
+find_package(Catch2 2.13.7 QUIET)
 if(NOT Catch2_FOUND)
   include(FetchContent)
   FetchContent_Declare(catch2
                        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                       GIT_TAG v2.9.1)
+                       GIT_TAG v2.13.7)
 
   FetchContent_GetProperties(catch2)
   if(NOT catch2_POPULATED)


### PR DESCRIPTION
`v2.9.1` of catch2 fails to compile on apple m1 due to this
https://github.com/catchorg/Catch2/pull/1084

Tested on MacOS Monterey
* with `Apple clang version 13.0.0 (clang-1300.0.29.3)`
* All tests pass