### PR TITLE
Remove redundant non-const member functions

### DIFF
--- a/code/include/rlbox.hpp
+++ b/code/include/rlbox.hpp
@@ -40,7 +40,6 @@ public:
    * @brief Unwrap a tainted value without verification. This is an unsafe
    * operation and should be used with care.
    */
-  inline auto UNSAFE_unverified() { return impl().get_raw_value(); }
   inline auto UNSAFE_unverified() const { return impl().get_raw_value(); }
   /**
    * @brief Like UNSAFE_unverified, but get the underlying sandbox
@@ -51,10 +50,6 @@ public:
    * For the Wasm-based sandbox, this function additionally validates the
    * unwrapped value against the machine model of the sandbox (LP32).
    */
-  inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox)
-  {
-    return impl().get_raw_sandbox_value(sandbox);
-  }
   inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox) const
   {
     return impl().get_raw_sandbox_value(sandbox);
@@ -66,44 +61,41 @@ public:
    *
    * @param reason An explanation why the unverified unwrapping is safe.
    */
-  rlbox_detail_member_and_const(
-    template<size_t N>
-    inline auto unverified_safe_because(const char (&reason)[N]),
+  template<size_t N>
+  inline auto unverified_safe_because(const char (&reason)[N]) const
+  {
+    RLBOX_UNUSED(reason);
+    static_assert(!std::is_pointer_v<T>,
+                  "unverified_safe_because does not support pointers. Use "
+                  "unverified_safe_pointer_because.");
+    return UNSAFE_unverified();
+  }
+
+  template<size_t N>
+  inline auto unverified_safe_pointer_because(size_t count,
+                                              const char (&reason)[N]) const
+  {
+    RLBOX_UNUSED(reason);
+
+    static_assert(std::is_pointer_v<T>, "Expected pointer type");
+    using T_Pointed = std::remove_pointer_t<T>;
+    if_constexpr_named(cond1, std::is_pointer_v<T_Pointed>)
     {
-      RLBOX_UNUSED(reason);
-      static_assert(!std::is_pointer_v<T>,
-                    "unverified_safe_because does not support pointers. Use "
-                    "unverified_safe_pointer_because.");
-      return UNSAFE_unverified();
-    });
+      rlbox_detail_static_fail_because(
+        cond1,
+        "There is no way to use unverified_safe_pointer_because for "
+        "'pointers to pointers' safely. Use copy_and_verify instead.");
+      return nullptr;
+    }
 
-  rlbox_detail_member_and_const(
-    template<size_t N>
-    inline auto unverified_safe_pointer_because(size_t count,
-                                                const char (&reason)[N]),
-    {
-      RLBOX_UNUSED(reason);
+    auto ret = UNSAFE_unverified();
+    if (ret != nullptr) {
+      size_t bytes = sizeof(T) * count;
+      detail::check_range_doesnt_cross_app_sbx_boundary<T_Sbx>(ret, bytes);
+    }
+    return ret;
+  }
 
-      static_assert(std::is_pointer_v<T>, "Expected pointer type");
-      using T_Pointed = std::remove_pointer_t<T>;
-      if_constexpr_named(cond1, std::is_pointer_v<T_Pointed>)
-      {
-        rlbox_detail_static_fail_because(
-          cond1,
-          "There is no way to use unverified_safe_pointer_because for "
-          "'pointers to pointers' safely. Use copy_and_verify instead.");
-        return nullptr;
-      }
-
-      auto ret = UNSAFE_unverified();
-      if (ret != nullptr) {
-        size_t bytes = sizeof(T) * count;
-        detail::check_range_doesnt_cross_app_sbx_boundary<T_Sbx>(ret, bytes);
-      }
-      return ret;
-    });
-
-  inline auto INTERNAL_unverified_safe() { return UNSAFE_unverified(); }
   inline auto INTERNAL_unverified_safe() const { return UNSAFE_unverified(); }
 
 #define BinaryOpValAndPtr(opSymbol)                                            \
@@ -427,7 +419,7 @@ public:
   template<typename T_Rhs>
   inline T_OpSubscriptArrRet& operator[](T_Rhs&& rhs)
   {
-    rlbox_detail_forward_to_const_a(operator[], T_OpSubscriptArrRet&, rhs);
+    rlbox_detail_forward_to_const(operator[], T_OpSubscriptArrRet&, rhs);
   }
 
 private:
@@ -446,29 +438,20 @@ public:
     return *ret_ptr;
   }
 
-  inline T_OpDerefRet& operator*()
-  {
-    rlbox_detail_forward_to_const(operator*, T_OpDerefRet&);
-  }
-
   // We need to implement the -> operator even if T is not a struct
   // So that we can support code patterns such as the below
   // tainted<T*> a;
   // a->UNSAFE_unverified();
-  inline auto operator->() const
+  inline const T_OpDerefRet* operator->() const
   {
     static_assert(std::is_pointer_v<T>,
                   "Operator -> only supported for pointer types");
-    auto ret = impl().get_raw_value();
-    using T_Ret = std::remove_pointer_t<T>;
-    using T_RetWrap = const tainted_volatile<T_Ret, T_Sbx>;
-    return reinterpret_cast<T_RetWrap*>(ret);
+    return reinterpret_cast<const T_OpDerefRet*>(impl().get_raw_value());
   }
 
-  inline auto operator->()
+  inline T_OpDerefRet* operator->()
   {
-    using T_Ret = tainted_volatile<std::remove_pointer_t<T>, T_Sbx>*;
-    rlbox_detail_forward_to_const(operator->, T_Ret);
+    rlbox_detail_forward_to_const(operator->, T_OpDerefRet*);
   }
 
   inline auto operator!()
@@ -737,7 +720,7 @@ public:
    * @return Whatever the verifier function returns.
    */
   template<typename T_Func>
-  inline auto copy_and_verify_address(T_Func verifier)
+  inline auto copy_and_verify_address(T_Func verifier) const
   {
     static_assert(std::is_pointer_v<T>,
                   "copy_and_verify_address must be used on pointers");
@@ -760,7 +743,8 @@ public:
    * @return Whatever the verifier function returns.
    */
   template<typename T_Func>
-  inline auto copy_and_verify_buffer_address(T_Func verifier, std::size_t size)
+  inline auto copy_and_verify_buffer_address(T_Func verifier,
+                                             std::size_t size) const
   {
     static_assert(std::is_pointer_v<T>,
                   "copy_and_verify_address must be used on pointers");
@@ -927,18 +911,6 @@ private:
                            adjust_type_context::SANDBOX>(
       ret, data, nullptr /* example_unsandboxed_ptr */, &sandbox);
     return ret;
-  };
-
-  inline std::remove_cv_t<T_AppType> get_raw_value() noexcept
-  {
-    rlbox_detail_forward_to_const(get_raw_value, std::remove_cv_t<T_AppType>);
-  }
-
-  inline std::remove_cv_t<T_SandboxedType> get_raw_sandbox_value(
-    rlbox_sandbox<T_Sbx>& sandbox)
-  {
-    rlbox_detail_forward_to_const_a(
-      get_raw_sandbox_value, std::remove_cv_t<T_SandboxedType>, sandbox);
   };
 
   inline const void* find_example_pointer_or_null() const noexcept
@@ -1193,25 +1165,6 @@ private:
   {
     RLBOX_UNUSED(sandbox);
     return data;
-  };
-
-  inline std::remove_cv_t<T_AppType> get_raw_value()
-  {
-    rlbox_detail_forward_to_const(get_raw_value, std::remove_cv_t<T_AppType>);
-  }
-
-  inline std::remove_cv_t<T_SandboxedType> get_raw_sandbox_value() noexcept
-  {
-    rlbox_detail_forward_to_const(get_raw_sandbox_value,
-                                  std::remove_cv_t<T_SandboxedType>);
-  };
-
-  inline std::remove_cv_t<T_SandboxedType> get_raw_sandbox_value(
-    rlbox_sandbox<T_Sbx>& sandbox) noexcept
-  {
-    RLBOX_UNUSED(sandbox);
-    rlbox_detail_forward_to_const(get_raw_sandbox_value,
-                                  std::remove_cv_t<T_SandboxedType>);
   };
 
   tainted_volatile() = default;

--- a/code/include/rlbox.hpp
+++ b/code/include/rlbox.hpp
@@ -419,7 +419,7 @@ public:
   template<typename T_Rhs>
   inline T_OpSubscriptArrRet& operator[](T_Rhs&& rhs)
   {
-    rlbox_detail_forward_to_const(operator[], T_OpSubscriptArrRet&, rhs);
+    return const_cast<T_OpSubscriptArrRet&>(std::as_const(*this)[rhs]);
   }
 
 private:
@@ -451,7 +451,7 @@ public:
 
   inline T_OpDerefRet* operator->()
   {
-    rlbox_detail_forward_to_const(operator->, T_OpDerefRet*);
+    return const_cast<T_OpDerefRet*>(std::as_const(*this).operator->());
   }
 
   inline auto operator!()
@@ -1176,14 +1176,12 @@ public:
     auto ref =
       detail::remove_volatile_from_ptr_cast(&this->get_sandbox_value_ref());
     auto ref_cast = reinterpret_cast<const T*>(ref);
-    auto ret = tainted<const T*, T_Sbx>::internal_factory(ref_cast);
-    return ret;
+    return tainted<const T*, T_Sbx>::internal_factory(ref_cast);
   }
 
   inline tainted<T*, T_Sbx> operator&() noexcept
   {
-    using T_Ret = tainted<T*, T_Sbx>;
-    rlbox_detail_forward_to_const(operator&, T_Ret);
+    return sandbox_const_cast<T*>(&std::as_const(*this));
   }
 
   // Needed as the definition of unary & above shadows the base's binary &

--- a/code/include/rlbox_helpers.hpp
+++ b/code/include/rlbox_helpers.hpp
@@ -98,46 +98,17 @@ namespace detail {
   }                                                                            \
   RLBOX_REQUIRE_SEMI_COLON
 
-#define rlbox_detail_forward_to_const(func_name, result_type)                  \
-  using T_ConstClassPtr = std::add_pointer_t<                                  \
-    std::add_const_t<std::remove_pointer_t<decltype(this)>>>;                  \
-  if constexpr (detail::rlbox_is_tainted_v<result_type> &&                     \
-                !std::is_reference_v<result_type>) {                           \
-    return sandbox_const_cast<detail::rlbox_remove_wrapper_t<result_type>>(    \
-      const_cast<T_ConstClassPtr>(this)->func_name());                         \
-  } else if constexpr (detail::is_fundamental_or_enum_v<result_type> ||        \
-                       detail::is_std_array_v<result_type> ||                  \
-                       detail::is_func_ptr_v<result_type> ||                   \
-                       std::is_class_v<result_type>) {                         \
-    return const_cast<T_ConstClassPtr>(this)->func_name();                     \
-  } else {                                                                     \
-    return const_cast<result_type>(                                            \
-      const_cast<T_ConstClassPtr>(this)->func_name());                         \
-  }
-
-#define rlbox_detail_forward_to_const_a(func_name, result_type, ...)           \
+#define rlbox_detail_forward_to_const(func_name, result_type, ...)             \
   using T_ConstClassPtr = std::add_pointer_t<                                  \
     std::add_const_t<std::remove_pointer_t<decltype(this)>>>;                  \
   if constexpr (detail::rlbox_is_tainted_v<result_type> &&                     \
                 !std::is_reference_v<result_type>) {                           \
     return sandbox_const_cast<detail::rlbox_remove_wrapper_t<result_type>>(    \
       const_cast<T_ConstClassPtr>(this)->func_name(__VA_ARGS__));              \
-  } else if constexpr (detail::is_fundamental_or_enum_v<result_type> ||        \
-                       detail::is_std_array_v<result_type> ||                  \
-                       detail::is_func_ptr_v<result_type> ||                   \
-                       std::is_class_v<result_type>) {                         \
-    return const_cast<T_ConstClassPtr>(this)->func_name(__VA_ARGS__);          \
   } else {                                                                     \
     return const_cast<result_type>(                                            \
       const_cast<T_ConstClassPtr>(this)->func_name(__VA_ARGS__));              \
   }
-
-#define rlbox_detail_member_and_const(sig, ...)                                \
-  sig __VA_ARGS__                                                              \
-                                                                               \
-    sig const __VA_ARGS__                                                      \
-                                                                               \
-    static_assert(true)
 
   template<typename T>
   inline auto remove_volatile_from_ptr_cast(T* ptr)

--- a/code/include/rlbox_helpers.hpp
+++ b/code/include/rlbox_helpers.hpp
@@ -98,18 +98,6 @@ namespace detail {
   }                                                                            \
   RLBOX_REQUIRE_SEMI_COLON
 
-#define rlbox_detail_forward_to_const(func_name, result_type, ...)             \
-  using T_ConstClassPtr = std::add_pointer_t<                                  \
-    std::add_const_t<std::remove_pointer_t<decltype(this)>>>;                  \
-  if constexpr (detail::rlbox_is_tainted_v<result_type> &&                     \
-                !std::is_reference_v<result_type>) {                           \
-    return sandbox_const_cast<detail::rlbox_remove_wrapper_t<result_type>>(    \
-      const_cast<T_ConstClassPtr>(this)->func_name(__VA_ARGS__));              \
-  } else {                                                                     \
-    return const_cast<result_type>(                                            \
-      const_cast<T_ConstClassPtr>(this)->func_name(__VA_ARGS__));              \
-  }
-
   template<typename T>
   inline auto remove_volatile_from_ptr_cast(T* ptr)
   {

--- a/code/include/rlbox_policy_types.hpp
+++ b/code/include/rlbox_policy_types.hpp
@@ -100,11 +100,6 @@ private:
   {
     return callback_trampoline;
   }
-  inline T_Callback get_raw_value() noexcept { return callback; }
-  inline T_Trampoline get_raw_sandbox_value() noexcept
-  {
-    return callback_trampoline;
-  }
 
   // Keep constructor private as only rlbox_sandbox should be able to create
   // this object
@@ -177,12 +172,6 @@ public:
     RLBOX_UNUSED(sandbox);
     return get_raw_sandbox_value();
   }
-  inline auto UNSAFE_unverified() noexcept { return get_raw_value(); }
-  inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox) noexcept
-  {
-    RLBOX_UNUSED(sandbox);
-    return get_raw_sandbox_value();
-  }
 };
 
 template<typename T, typename T_Sbx>
@@ -210,11 +199,6 @@ private:
     return to_tainted().get_raw_value();
   }
   inline typename T_Sbx::T_PointerType get_raw_sandbox_value() const noexcept
-  {
-    return idx;
-  }
-  inline T get_raw_value() noexcept { return to_tainted().get_raw_value(); }
-  inline typename T_Sbx::T_PointerType get_raw_sandbox_value() noexcept
   {
     return idx;
   }
@@ -286,12 +270,6 @@ public:
     RLBOX_UNUSED(sandbox);
     return get_raw_sandbox_value();
   }
-  inline auto UNSAFE_unverified() noexcept { return get_raw_value(); }
-  inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox) noexcept
-  {
-    RLBOX_UNUSED(sandbox);
-    return get_raw_sandbox_value();
-  }
 };
 
 /**
@@ -315,7 +293,7 @@ public:
     val = rhs;
     return *this;
   }
-  inline tainted_boolean_hint operator!() { return tainted_boolean_hint(!val); }
+  inline tainted_boolean_hint operator!() const { return tainted_boolean_hint(!val); }
   template<size_t N>
   inline bool unverified_safe_because(const char (&reason)[N]) const
   {
@@ -323,8 +301,6 @@ public:
     return val;
   }
   inline bool UNSAFE_unverified() const { return val; }
-  inline bool UNSAFE_unverified() { return val; }
-  inline auto INTERNAL_unverified_safe() { return UNSAFE_unverified(); }
   inline auto INTERNAL_unverified_safe() const { return UNSAFE_unverified(); }
 
   // Add a template parameter to make sure the assert only fires when called
@@ -373,7 +349,7 @@ public:
     val = rhs;
     return *this;
   }
-  inline tainted_boolean_hint operator!() { return tainted_boolean_hint(!val); }
+  inline tainted_boolean_hint operator!() const { return tainted_boolean_hint(!val); }
   template<size_t N>
   inline int unverified_safe_because(const char (&reason)[N]) const
   {
@@ -381,8 +357,6 @@ public:
     return val;
   }
   inline int UNSAFE_unverified() const { return val; }
-  inline int UNSAFE_unverified() { return val; }
-  inline auto INTERNAL_unverified_safe() { return UNSAFE_unverified(); }
   inline auto INTERNAL_unverified_safe() const { return UNSAFE_unverified(); }
 
   // Add a template parameter to make sure the assert only fires when called

--- a/code/include/rlbox_struct_support.hpp
+++ b/code/include/rlbox_struct_support.hpp
@@ -30,8 +30,9 @@ template<typename T, typename T_Sbx>
 using convert_to_sandbox_equivalent_t =
   typename convert_to_sandbox_equivalent_helper<T, T_Sbx>::type;
 
-  // This is used by rlbox_load_structs_from_library to test the current namespace
-  struct markerStruct {};
+// This is used by rlbox_load_structs_from_library to test the current namespace
+struct markerStruct
+{};
 }
 
 #define helper_create_converted_field(fieldType, fieldName, isFrozen)          \
@@ -126,18 +127,6 @@ using convert_to_sandbox_equivalent_t =
       return *ret_ptr;                                                         \
     }                                                                          \
                                                                                \
-    inline std::remove_cv_t<T> get_raw_value() noexcept                        \
-    {                                                                          \
-      rlbox_detail_forward_to_const(get_raw_value, std::remove_cv_t<T>);       \
-    }                                                                          \
-                                                                               \
-    inline std::remove_cv_t<Sbx_##libId##_##T<T_Sbx>>                          \
-    get_raw_sandbox_value() noexcept                                           \
-    {                                                                          \
-      rlbox_detail_forward_to_const(                                           \
-        get_raw_sandbox_value, std::remove_cv_t<Sbx_##libId##_##T<T_Sbx>>);    \
-    }                                                                          \
-                                                                               \
     tainted_volatile() = default;                                              \
     tainted_volatile(const tainted_volatile<MaybeConst T, T_Sbx>& p) =         \
       default;                                                                 \
@@ -148,8 +137,7 @@ using convert_to_sandbox_equivalent_t =
       helper_no_op,                                                            \
       MaybeConst)                                                              \
                                                                                \
-      inline tainted<MaybeConst T*, T_Sbx>                                     \
-      operator&() noexcept                                                     \
+    inline tainted<MaybeConst T*, T_Sbx> operator&() const noexcept            \
     {                                                                          \
       auto ref_cast =                                                          \
         reinterpret_cast<MaybeConst T*>(&get_sandbox_value_ref());             \
@@ -157,23 +145,12 @@ using convert_to_sandbox_equivalent_t =
       return ret;                                                              \
     }                                                                          \
                                                                                \
-    inline auto UNSAFE_unverified() { return get_raw_value(); }                \
     inline auto UNSAFE_unverified() const { return get_raw_value(); }          \
-    inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox)                \
-    {                                                                          \
-      return get_raw_sandbox_value(sandbox);                                   \
-    }                                                                          \
     inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox) const          \
     {                                                                          \
       return get_raw_sandbox_value(sandbox);                                   \
     }                                                                          \
                                                                                \
-    template<size_t N>                                                         \
-    inline auto unverified_safe_because(const char (&reason)[N])               \
-    {                                                                          \
-      RLBOX_UNUSED(reason);                                                    \
-      return UNSAFE_unverified();                                              \
-    }                                                                          \
     template<size_t N>                                                         \
     inline auto unverified_safe_because(const char (&reason)[N]) const         \
     {                                                                          \
@@ -233,20 +210,6 @@ using convert_to_sandbox_equivalent_t =
         return lhs;                                                            \
     }                                                                          \
                                                                                \
-    inline std::remove_cv_t<T> get_raw_value() noexcept                        \
-    {                                                                          \
-      rlbox_detail_forward_to_const(get_raw_value, std::remove_cv_t<T>);       \
-    }                                                                          \
-                                                                               \
-    inline std::remove_cv_t<Sbx_##libId##_##T<T_Sbx>> get_raw_sandbox_value(   \
-      rlbox_sandbox<T_Sbx>& sandbox) noexcept                                  \
-    {                                                                          \
-      rlbox_detail_forward_to_const_a(                                         \
-        get_raw_sandbox_value,                                                 \
-        std::remove_cv_t<Sbx_##libId##_##T<T_Sbx>>,                            \
-        sandbox);                                                              \
-    }                                                                          \
-                                                                               \
     inline const void* find_example_pointer_or_null() const noexcept           \
     {                                                                          \
       sandbox_fields_reflection_##libId##_class_##T(                           \
@@ -260,7 +223,7 @@ using convert_to_sandbox_equivalent_t =
                                                   helper_no_op,                \
                                                   MaybeConst)                  \
                                                                                \
-      tainted() = default;                                                     \
+    tainted() = default;                                                       \
     tainted(const tainted<MaybeConst T, T_Sbx>& p) = default;                  \
                                                                                \
     tainted(const tainted_volatile<T, T_Sbx>& p)                               \
@@ -283,23 +246,12 @@ using convert_to_sandbox_equivalent_t =
       return *reinterpret_cast<tainted_opaque<MaybeConst T, T_Sbx>*>(this);    \
     }                                                                          \
                                                                                \
-    inline auto UNSAFE_unverified() { return get_raw_value(); }                \
     inline auto UNSAFE_unverified() const { return get_raw_value(); }          \
-    inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox)                \
-    {                                                                          \
-      return get_raw_sandbox_value(sandbox);                                   \
-    }                                                                          \
     inline auto UNSAFE_sandboxed(rlbox_sandbox<T_Sbx>& sandbox) const          \
     {                                                                          \
       return get_raw_sandbox_value(sandbox);                                   \
     }                                                                          \
                                                                                \
-    template<size_t N>                                                         \
-    inline auto unverified_safe_because(const char (&reason)[N])               \
-    {                                                                          \
-      RLBOX_UNUSED(reason);                                                    \
-      return UNSAFE_unverified();                                              \
-    }                                                                          \
     template<size_t N>                                                         \
     inline auto unverified_safe_because(const char (&reason)[N]) const         \
     {                                                                          \
@@ -335,8 +287,8 @@ using convert_to_sandbox_equivalent_t =
   }
 
 #define tainted_data_specialization(T, libId)                                  \
-  tainted_data_specialization_helper(, T, libId)                               \
-    tainted_data_specialization_helper(const, T, libId)
+  tainted_data_specialization_helper(     , T, libId)                          \
+  tainted_data_specialization_helper(const, T, libId)
 
 #define convert_type_specialization(T, libId)                                  \
   namespace detail {                                                           \


### PR DESCRIPTION
A number of non-`const` member functions in the tainted types do exactly the same things as their `const` counterparts. These non-`const` functions can therefore be removed without affecting the end-user.

One consequence of the change above is that the `rlbox_detail_forward_to_const` macro can now be simplified to cover only the cases where non-`const` member functions actually differ from their `const` counterparts.